### PR TITLE
Update tag trigger

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,7 +14,7 @@ on:
       - '!examples/**'
     branches: [ "main" ]
     # Publish semver tags as releases.
-    tags: [ 'v*.*.*' ]
+    tags: [ 'v*.*', 'v*.*.*' ]
   pull_request:
     paths:
       - 'Dockerfile'


### PR DESCRIPTION
This pull request includes a change in the `.github/workflows/docker-publish.yml` file. The change modifies the tag pattern for publishing semver tags as releases. Now, it will also consider tags in the format 'v*.*' in addition to 'v*.*.*'.