### PR TITLE
Use a builder image, remove expose lines. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 ARG BASE_IMAGE=alpine:3.19
-FROM ${BASE_IMAGE}
 
-LABEL org.opencontainers.image.authors="Chris Romp NZ6F"
-LABEL org.opencontainers.image.description="HamClock by WBØOEW in a Docker container"
-LABEL org.opencontainers.image.source="https://github.com/ChrisRomp/hamclock-docker"
+# Builder Image
+FROM ${BASE_IMAGE} as builder
 
 # HamClock supported resolutions are 800x480, 1600x960, 2400x1440 and 3200x1920 as of v3.02
 ARG HAMCLOCK_RESOLUTION=1600x960
@@ -25,19 +23,22 @@ WORKDIR /hamclock/ESPHamClock
 RUN make -j 4 hamclock-web-${HAMCLOCK_RESOLUTION}
 RUN make install
 
-USER root
+# Actual docker image
+FROM ${BASE_IMAGE}
 
-# HamClock REST API
-EXPOSE 8080/tcp
-# HamClock Web UI
-EXPOSE 8081/tcp
+LABEL org.opencontainers.image.authors="Chris Romp NZ6F"
+LABEL org.opencontainers.image.description="HamClock by WBØOEW in a Docker container"
+LABEL org.opencontainers.image.source="https://github.com/ChrisRomp/hamclock-docker"
 
 # Persist HamClock settings outside of container
 VOLUME /root/.hamclock
+RUN apk update && apk upgrade
+RUN apk add libstdc++
+
+copy --from=builder /usr/local/bin/hamclock /usr/local/bin/hamclock
 
 # Healtheck - call REST API, give it 2 mins to get through setup
 HEALTHCHECK --interval=30s --timeout=10s --start-period=2m --retries=3 CMD curl -f http://localhost:8080/get_sys.txt || exit 1
 
 # Start HamClock
-WORKDIR /hamclock/ESPHamClock
 CMD ["/usr/local/bin/hamclock", "-o"]


### PR DESCRIPTION
I appreciate your work on the docker image. I've made some changes and wanted to send it back. 

First major change is the use of a build stage, this separates out the building of the hamclock project from actually running it. This makes the image smaller over all, and removes any unnecessary bits in the final image. 

Second minor change, I removed the EXPOSE lines. These are not actually used by docker for anything other then cluttering the `docker ps` command. One still needs to use the `-p` or ports in docker-compose. 
