### PR TITLE
CI version check

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,87 @@
+name: Check for Updates
+
+on:
+  schedule:
+  - cron: "37 */2 * * *"
+  workflow_dispatch:
+
+jobs:
+  version-check:
+    name: Compare Local and Remote Versions
+    runs-on: ubuntu-latest
+    outputs:
+        update_required: ${{ steps.compare_versions.outputs.update_required }}
+        current_version: ${{ steps.get_release_version.outputs.current_version }}
+        remote_version: ${{ steps.get_remote_version.outputs.remote_version }}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Get remote version
+      id: get_remote_version
+      env:
+        VERSION_CHECK_URL: ${{ vars.VERSION_CHECK_URL }}
+      run: |
+        set -e
+        echo "Getting version from $VERSION_CHECK_URL"
+        REMOTE_VERSION=$(curl -s "$VERSION_CHECK_URL" | head -n 1)
+        echo "Got version: $REMOTE_VERSION"
+        echo "remote_version=$REMOTE_VERSION" >> "$GITHUB_OUTPUT"
+
+    - name: Get current release version
+      id: get_release_version
+      env:
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -e
+        URL="https://api.github.com/repos/$GITHUB_REPOSITORY/releases/latest"
+        echo "Getting version from $URL"
+        CURRENT_VERSION=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "$URL" | jq -r '.tag_name' | sed 's/^v//')
+        echo "Got version: $CURRENT_VERSION"
+        echo "current_version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+
+    - name: Compare versions
+      id: compare_versions
+      env:
+        CURRENT_VERSION : ${{ steps.get_release_version.outputs.current_version }}
+        REMOTE_VERSION : ${{ steps.get_remote_version.outputs.remote_version }}
+      run: |
+        set -e
+        if [ "$(printf '%s\n' "$CURRENT_VERSION" "$REMOTE_VERSION" | sort -V --reverse | head -n 1)" == "$CURRENT_VERSION" ]; then
+            echo "Current version $CURRENT_VERSION is greater than or equal to Remote version $REMOTE_VERSION."
+            echo "update_required=false" >> "$GITHUB_OUTPUT"
+        else
+            echo "Remote version $REMOTE_VERSION is newer than Current version $CURRENT_VERSION."
+            echo "update_required=true" >> "$GITHUB_OUTPUT"
+        fi
+
+  new-release:
+    name: Create New Release
+    runs-on: ubuntu-latest
+    needs: version-check
+    if: ${{ needs.version-check.outputs.update_required == 'true' }}
+    permissions:
+        contents: write
+
+    steps:
+    - name: Get Release Notes
+      env:
+        VERSION_CHECK_URL: ${{ vars.VERSION_CHECK_URL }}
+      run: |
+        set -e
+        echo "Getting release notes from $VERSION_CHECK_URL"
+        curl -s "$VERSION_CHECK_URL" > ./release_notes.txt
+
+    - name: Create Release
+      uses: softprops/action-gh-release@v2
+      env:
+          GITHUB_TOKEN: ${{ secrets.PAT_GITHUB }}
+          NEW_VERSION: ${{ needs.version-check.outputs.remote_version }}
+      with:
+          tag_name: v${{ needs.version-check.outputs.remote_version }}
+          body_path: ./release_notes.txt
+          generate_release_notes: true
+          append_body: true
+          make_latest: true

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -26,7 +26,7 @@ jobs:
         set -e
         echo "Getting version from $VERSION_CHECK_URL"
         REMOTE_VERSION=$(curl -s "$VERSION_CHECK_URL" | head -n 1)
-        echo "Got version: $REMOTE_VERSION" >> $GITHUB_STEP_SUMMARY
+        echo "Remote version: $REMOTE_VERSION" >> $GITHUB_STEP_SUMMARY
         echo "remote_version=$REMOTE_VERSION" >> "$GITHUB_OUTPUT"
 
     - name: Get current release version
@@ -39,7 +39,7 @@ jobs:
         URL="https://api.github.com/repos/$GITHUB_REPOSITORY/releases/latest"
         echo "Getting version from $URL"
         CURRENT_VERSION=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "$URL" | jq -r '.tag_name' | sed 's/^v//')
-        echo "Got version: $CURRENT_VERSION" >> $GITHUB_STEP_SUMMARY
+        echo "Current version: $CURRENT_VERSION" >> $GITHUB_STEP_SUMMARY
         echo "current_version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
 
     - name: Compare versions

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -26,7 +26,7 @@ jobs:
         set -e
         echo "Getting version from $VERSION_CHECK_URL"
         REMOTE_VERSION=$(curl -s "$VERSION_CHECK_URL" | head -n 1)
-        echo "Got version: $REMOTE_VERSION"
+        echo "Got version: $REMOTE_VERSION" >> $GITHUB_STEP_SUMMARY
         echo "remote_version=$REMOTE_VERSION" >> "$GITHUB_OUTPUT"
 
     - name: Get current release version
@@ -39,7 +39,7 @@ jobs:
         URL="https://api.github.com/repos/$GITHUB_REPOSITORY/releases/latest"
         echo "Getting version from $URL"
         CURRENT_VERSION=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "$URL" | jq -r '.tag_name' | sed 's/^v//')
-        echo "Got version: $CURRENT_VERSION"
+        echo "Got version: $CURRENT_VERSION" >> $GITHUB_STEP_SUMMARY
         echo "current_version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
 
     - name: Compare versions
@@ -51,9 +51,11 @@ jobs:
         set -e
         if [ "$(printf '%s\n' "$CURRENT_VERSION" "$REMOTE_VERSION" | sort -V --reverse | head -n 1)" == "$CURRENT_VERSION" ]; then
             echo "Current version $CURRENT_VERSION is greater than or equal to Remote version $REMOTE_VERSION."
+            echo "No update required." >> $GITHUB_STEP_SUMMARY
             echo "update_required=false" >> "$GITHUB_OUTPUT"
         else
             echo "Remote version $REMOTE_VERSION is newer than Current version $CURRENT_VERSION."
+            echo "Creating release... :rocket:" >> $GITHUB_STEP_SUMMARY
             echo "update_required=true" >> "$GITHUB_OUTPUT"
         fi
 


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow in the `.github/workflows/version-check.yml` file. This workflow is designed to automatically check for updates to the software and create a new release if a newer version is available.
Fixes #16 

Here are the key changes:

* A new workflow is scheduled to run every two hours and can also be manually triggered.
* The `version-check` job checks out the repository, retrieves the remote version from a specified URL, retrieves the current release version from the GitHub API, and compares the two versions. If the remote version is newer, it sets an output variable `update_required` to `true`.
* The `new-release` job runs if `update_required` is `true`, retrieves release notes from a specified URL, and uses the `softprops/action-gh-release@v2` action to create a new release with the remote version.