### PR TITLE
Split architecture builds for Docker build troubleshooting

### DIFF
--- a/.github/workflows/docker-build-amd64.yaml
+++ b/.github/workflows/docker-build-amd64.yaml
@@ -6,20 +6,9 @@ name: Docker Build AMD64
 # documentation.
 
 on:
-  # schedule:
-  #   - cron: '22 23 * * *'
-  # push:
-  #   paths:
-  #     - 'Dockerfile'
-  #     - '!examples/**'
-  #   branches: [ "main" ]
-  #   # Publish semver tags as releases.
-  #   tags: [ 'v*.*', 'v*.*.*' ]
-  # pull_request:
-  #   paths:
-  #     - 'Dockerfile'
-  #     - '!examples/**'
-  #   branches: [ "main" ]
+  push:
+    paths:
+      - '.github/workflows/docker-build-amd64.yaml'
   workflow_dispatch:
 
 env:
@@ -30,52 +19,20 @@ env:
 
 jobs:
   build:
-    name: Build and push Docker image
+    name: Build Docker image
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      # packages: write
-      # This is used to complete the identity challenge
-      # with sigstore/fulcio when running outside of PRs.
-      # id-token: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      # Install the cosign tool except on PR
-      # https://github.com/sigstore/cosign-installer
-      - name: Install cosign
-        if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v3.7.0
-        # with:
-          # cosign-release: 'v2.2.4'
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.8.0
-
-      # # Login against a Docker registry except on PR
-      # # https://github.com/docker/login-action
-      # - name: Log into registry ${{ env.REGISTRY }}
-      #   if: github.event_name != 'pull_request'
-      #   uses: docker/login-action@v3.3.0
-      #   with:
-      #     registry: ${{ env.REGISTRY }}
-      #     username: ${{ github.actor }}
-      #     password: ${{ secrets.GITHUB_TOKEN }}
-
-      # Extract metadata (tags, labels) for Docker
-      # https://github.com/docker/metadata-action
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5.6.1
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          flavor: |
-            latest=auto
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
@@ -85,8 +42,6 @@ jobs:
         with:
           context: .
           platforms: linux/amd64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          push: false
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker-build-amd64.yaml
+++ b/.github/workflows/docker-build-amd64.yaml
@@ -34,9 +34,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.8.0
 
-      # Build and push Docker image with Buildx (don't push on PR)
+      # Build Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
-      - name: Build and push Docker image
+      - name: Build Docker image
         id: build-and-push
         uses: docker/build-push-action@v6.13.0
         with:

--- a/.github/workflows/docker-build-amd64.yaml
+++ b/.github/workflows/docker-build-amd64.yaml
@@ -1,0 +1,92 @@
+name: Docker Build AMD64
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  # schedule:
+  #   - cron: '22 23 * * *'
+  # push:
+  #   paths:
+  #     - 'Dockerfile'
+  #     - '!examples/**'
+  #   branches: [ "main" ]
+  #   # Publish semver tags as releases.
+  #   tags: [ 'v*.*', 'v*.*.*' ]
+  # pull_request:
+  #   paths:
+  #     - 'Dockerfile'
+  #     - '!examples/**'
+  #   branches: [ "main" ]
+  workflow_dispatch:
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      # id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@v3.7.0
+        # with:
+          # cosign-release: 'v2.2.4'
+
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.8.0
+
+      # # Login against a Docker registry except on PR
+      # # https://github.com/docker/login-action
+      # - name: Log into registry ${{ env.REGISTRY }}
+      #   if: github.event_name != 'pull_request'
+      #   uses: docker/login-action@v3.3.0
+      #   with:
+      #     registry: ${{ env.REGISTRY }}
+      #     username: ${{ github.actor }}
+      #     password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5.6.1
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=auto
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v6.13.0
+        with:
+          context: .
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-build-arm64.yaml
+++ b/.github/workflows/docker-build-arm64.yaml
@@ -42,7 +42,7 @@ jobs:
         with:
           context: .
           build-args:
-            - DEBUG: "true"
+            - DEBUG_BUILD: "true"
           platforms: linux/arm64
           push: false
           cache-from: type=gha

--- a/.github/workflows/docker-build-arm64.yaml
+++ b/.github/workflows/docker-build-arm64.yaml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   build:
-    name: Build and push Docker image
+    name: Build Docker image
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -34,9 +34,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.8.0
 
-      # Build and push Docker image with Buildx (don't push on PR)
+      # Build Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
-      - name: Build and push Docker image
+      - name: Build Docker image
         id: build-and-push
         uses: docker/build-push-action@v6.13.0
         with:

--- a/.github/workflows/docker-build-arm64.yaml
+++ b/.github/workflows/docker-build-arm64.yaml
@@ -41,6 +41,8 @@ jobs:
         uses: docker/build-push-action@v6.13.0
         with:
           context: .
+          build-args:
+            - DEBUG: "true"
           platforms: linux/arm64
           push: false
           cache-from: type=gha

--- a/.github/workflows/docker-build-arm64.yaml
+++ b/.github/workflows/docker-build-arm64.yaml
@@ -41,8 +41,7 @@ jobs:
         uses: docker/build-push-action@v6.13.0
         with:
           context: .
-          build-args:
-            - DEBUG_BUILD: "true"
+          build-args: DEBUG_BUILD="true"
           platforms: linux/arm64
           push: false
           cache-from: type=gha

--- a/.github/workflows/docker-build-arm64.yaml
+++ b/.github/workflows/docker-build-arm64.yaml
@@ -1,0 +1,47 @@
+name: Docker Build Arm64
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  push:
+    paths:
+      - '.github/workflows/docker-build-arm64.yaml'
+  workflow_dispatch:
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.8.0
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v6.13.0
+        with:
+          context: .
+          platforms: linux/arm64
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-build-arm64.yaml
+++ b/.github/workflows/docker-build-arm64.yaml
@@ -41,7 +41,6 @@ jobs:
         uses: docker/build-push-action@v6.13.0
         with:
           context: .
-          build-args: DEBUG_BUILD="true"
           platforms: linux/arm64
           push: false
           cache-from: type=gha

--- a/.github/workflows/docker-build-armv7.yaml
+++ b/.github/workflows/docker-build-armv7.yaml
@@ -1,0 +1,47 @@
+name: Docker Build ARMv7
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  push:
+    paths:
+      - '.github/workflows/docker-build-armv7.yaml'
+  workflow_dispatch:
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.8.0
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v6.13.0
+        with:
+          context: .
+          platforms: linux/arm/v7
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-build-armv7.yaml
+++ b/.github/workflows/docker-build-armv7.yaml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   build:
-    name: Build and push Docker image
+    name: Build Docker image
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -34,9 +34,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.8.0
 
-      # Build and push Docker image with Buildx (don't push on PR)
+      # Build Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
-      - name: Build and push Docker image
+      - name: Build Docker image
         id: build-and-push
         uses: docker/build-push-action@v6.13.0
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ RUN curl -O https://www.clearskyinstitute.com/ham/HamClock/ESPHamClock.zip && \
     unzip ESPHamClock.zip
 WORKDIR /hamclock/ESPHamClock
 
+# TESTING change optimization level to -O2
+RUN sed -i '' 's/-O3/-O2/g' /hamclock/ESPHamClock/Makefile
+
 # Let's build it
 RUN make -j 4 hamclock-web-${HAMCLOCK_RESOLUTION}
 RUN make install

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN curl -O https://www.clearskyinstitute.com/ham/HamClock/ESPHamClock.zip && \
 WORKDIR /hamclock/ESPHamClock
 
 # TESTING change optimization level to -O2
+RUN chmod 664 Makefile
 RUN ls -alh Makefile
 RUN sed -i '' 's/-O3/-O2/g' Makefile
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /hamclock/ESPHamClock
 # TESTING change optimization level to -O2
 RUN chmod 664 Makefile
 RUN ls -alh Makefile
-RUN sed -i '' 's/-O3/-O2/g' Makefile
+RUN sed -i 's/-O3/-O2/g' Makefile
 
 # Let's build it
 RUN make -j 4 hamclock-web-${HAMCLOCK_RESOLUTION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,15 @@ RUN curl -O https://www.clearskyinstitute.com/ham/HamClock/ESPHamClock.zip && \
     unzip ESPHamClock.zip
 WORKDIR /hamclock/ESPHamClock
 
+# Enable debug builds
+ARG DEBUG=false
+
 # Let's build it
-RUN make -j 4 hamclock-web-${HAMCLOCK_RESOLUTION}
+RUN if [ "$DEBUG" = "true" ]; then \
+        make -j 4 CFLAGS="-Wall" hamclock-web-${HAMCLOCK_RESOLUTION}; \
+    else \
+        make -j 4 hamclock-web-${HAMCLOCK_RESOLUTION}; \
+    fi
 RUN make install
 
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN curl -O https://www.clearskyinstitute.com/ham/HamClock/ESPHamClock.zip && \
 WORKDIR /hamclock/ESPHamClock
 
 # TESTING change optimization level to -O2
+RUN ls -alh Makefile
 RUN sed -i '' 's/-O3/-O2/g' Makefile
 
 # Let's build it

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN curl -O https://www.clearskyinstitute.com/ham/HamClock/ESPHamClock.zip && \
 WORKDIR /hamclock/ESPHamClock
 
 # TESTING change optimization level to -O2
-RUN sed -i '' 's/-O3/-O2/g' /hamclock/ESPHamClock/Makefile
+RUN sed -i '' 's/-O3/-O2/g' Makefile
 
 # Let's build it
 RUN make -j 4 hamclock-web-${HAMCLOCK_RESOLUTION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=alpine:3.19
+ARG BASE_IMAGE=alpine:3.21
 FROM ${BASE_IMAGE}
 
 LABEL org.opencontainers.image.authors="Chris Romp NZ6F"
@@ -22,10 +22,10 @@ RUN curl -O https://www.clearskyinstitute.com/ham/HamClock/ESPHamClock.zip && \
 WORKDIR /hamclock/ESPHamClock
 
 # Enable debug builds
-ARG DEBUG=false
+ARG DEBUG_BUILD=false
 
 # Let's build it
-RUN if [ "$DEBUG" = "true" ]; then \
+RUN if [ "$DEBUG_BUILD" = "true" ]; then \
         make -j 4 CFLAGS="-Wall" hamclock-web-${HAMCLOCK_RESOLUTION}; \
     else \
         make -j 4 hamclock-web-${HAMCLOCK_RESOLUTION}; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,15 +21,8 @@ RUN curl -O https://www.clearskyinstitute.com/ham/HamClock/ESPHamClock.zip && \
     unzip ESPHamClock.zip
 WORKDIR /hamclock/ESPHamClock
 
-# Enable debug builds
-ARG DEBUG_BUILD=false
-
 # Let's build it
-RUN if [ "$DEBUG_BUILD" = "true" ]; then \
-        make -j 4 CFLAGS="-Wall" hamclock-web-${HAMCLOCK_RESOLUTION}; \
-    else \
-        make -j 4 hamclock-web-${HAMCLOCK_RESOLUTION}; \
-    fi
+RUN make -j 4 hamclock-web-${HAMCLOCK_RESOLUTION}
 RUN make install
 
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ RUN curl -O https://www.clearskyinstitute.com/ham/HamClock/ESPHamClock.zip && \
     unzip ESPHamClock.zip
 WORKDIR /hamclock/ESPHamClock
 
-# TESTING change optimization level to -O2
+# Change optimization level to -O2
+# Fixes build failure on ARM64
 RUN chmod 664 Makefile
 RUN ls -alh Makefile
 RUN sed -i 's/-O3/-O2/g' Makefile


### PR DESCRIPTION
This pull request introduces new GitHub Actions workflows to automate the building of Docker images for different architectures. The workflows are designed to build images for AMD64, ARM64, and ARMv7 platforms using Docker Buildx and caching mechanisms.

New GitHub Actions workflows:

* [`.github/workflows/docker-build-amd64.yaml`](diffhunk://#diff-697c2c9c6abb9deb848313be9f0d444ed9e8c04373eca24a1a2a1c30ebe9d0f4R1-R47): Added a workflow to build Docker images for the AMD64 architecture.
* [`.github/workflows/docker-build-arm64.yaml`](diffhunk://#diff-f6eab2f9cb51dd31f2f45aca29719d8c24308edb497a13f78fbe7aa1fbf739d4R1-R47): Added a workflow to build Docker images for the ARM64 architecture.
* [`.github/workflows/docker-build-armv7.yaml`](diffhunk://#diff-d86f0fc4f5231e56ddcf455ef811795c52d969dc00bbbecef414ae5517ee497fR1-R47): Added a workflow to build Docker images for the ARMv7 architecture.