### PR TITLE
Fix Dockerfile to include linux-headers package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG HAMCLOCK_RESOLUTION=1600x960
 
 # Install updates and required packages
 RUN apk update && apk upgrade
-RUN apk add curl make g++ libx11-dev perl
+RUN apk add curl make g++ libx11-dev perl linux-headers
 
 RUN mkdir /hamclock
 WORKDIR /hamclock


### PR DESCRIPTION
Fixes #49

Update Dockerfile to include linux-headers package

* Add `linux-headers` to the list of installed packages in the Dockerfile.
* Update the `RUN apk add` command to include `linux-headers`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ChrisRomp/hamclock-docker/pull/50?shareId=3d64d4b7-b99e-4213-b4e6-382748f3c2e8).