### PR TITLE
Update examples and remove deprecated version tag from YAML samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ To run:
 Or you can paste this YAML into a `docker-compose.yaml` file yourself:
 
 ```yaml
-version: "3"
 services:
   web:
     image: ghcr.io/chrisromp/hamclock-docker:latest

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   web:
     build:

--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -1,10 +1,11 @@
-version: "3"
 services:
   web:
     image: ghcr.io/chrisromp/hamclock-docker:latest
     ports:
       - "8080:8080/tcp"
       - "8081:8081/tcp"
+      # Uncomment below if you want to expose the read-only web interface on port 8082
+      #- "8082:8082/tcp" 
     volumes:
       - data:/root/.hamclock
     restart: unless-stopped


### PR DESCRIPTION
This pull request updates the Docker Compose configuration by upgrading the Compose file version and adding a new optional port mapping for the read-only web interface. Below are the key changes:
### Docker Compose version updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L57): Removed the `version: "3"` line from the example YAML configuration to align with the latest Docker Compose recommendations.
* [`docker-compose.yaml`](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L1): Removed the `version: "3"` line from the main Docker Compose configuration file.
* [`examples/docker-compose.yaml`](diffhunk://#diff-34686806ce7369ba8aea6b65936d44d3fe45a2799ac680b4f12741adaa0eed2bL1-R8): Removed the `version: "3"` line from the example Docker Compose configuration file.

### Example configuration improvements:
* [`examples/docker-compose.yaml`](diffhunk://#diff-34686806ce7369ba8aea6b65936d44d3fe45a2799ac680b4f12741adaa0eed2bL1-R8): Added a commented-out example for exposing a read-only web interface on port 8082, providing more flexibility for users.