### PR TITLE
Split CI download process to cache source before Docker builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,14 +10,14 @@ on:
   #   - cron: '22 23 * * *'
   push:
     paths:
-      - 'Dockerfile'
+      - 'Dockerfile-CI'
       - '!examples/**'
     branches: [ "main" ]
     # Publish semver tags as releases.
     tags: [ 'v*.*', 'v*.*.*' ]
   pull_request:
     paths:
-      - 'Dockerfile'
+      - 'Dockerfile-CI'
       - '!examples/**'
     branches: [ "main" ]
   workflow_dispatch:
@@ -29,6 +29,24 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  download:
+    name: Download Source
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Download from HamClock
+        run: curl -O https://www.clearskyinstitute.com/ham/HamClock/ESPHamClock.zip
+
+      - name: Cache ESPHamClock.zip
+        uses: actions/upload-artifact@v4
+        with:
+          name: ESPHamClock.zip
+          if-no-files-found: error
+          retention-days: 7
+          overwrite: true
+
   build:
     name: Build and push Docker image
     runs-on: ubuntu-latest
@@ -76,14 +94,21 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
             latest=auto
+      
+      # Download the ESPHamClock.zip artifact
+      - name: Download ESPHamClock.zip artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ESPHamClock.zip
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v6.16.0
+        uses: docker/build-push-action@v6
         with:
           context: .
+          file: Dockerfile-CI
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile-CI
+++ b/Dockerfile-CI
@@ -15,9 +15,10 @@ RUN apk add curl make g++ libx11-dev perl linux-headers
 RUN mkdir /hamclock
 WORKDIR /hamclock
 
-# Download HamClock source
+# COPY HamClock source from artifact downloaded by CI
+COPY ESPHamClock.zip /hamclock/
+
 # Sort-of following Desktop build steps from https://www.clearskyinstitute.com/ham/HamClock/
-RUN curl -O https://www.clearskyinstitute.com/ham/HamClock/ESPHamClock.zip
 RUN unzip ESPHamClock.zip
 WORKDIR /hamclock/ESPHamClock
 


### PR DESCRIPTION
This pull request introduces changes to streamline the CI/CD pipeline for publishing Docker images and adds a new `Dockerfile-CI` to support building HamClock in a containerized environment. The updates include modifications to the GitHub Actions workflow, adjustments to the original `Dockerfile`, and the creation of a new `Dockerfile-CI` optimized for CI builds.

### Workflow Enhancements:
* Updated `.github/workflows/docker-publish.yml` to replace `Dockerfile` with `Dockerfile-CI` in `push` and `pull_request` paths to align with the new CI build process.
* Added a new `download` job in `.github/workflows/docker-publish.yml` to fetch the HamClock source (`ESPHamClock.zip`) and cache it as an artifact for reuse.
* Modified the `build` job in `.github/workflows/docker-publish.yml` to download the cached artifact (`ESPHamClock.zip`) and use `Dockerfile-CI` for building the Docker image.

### Docker Configuration Updates:
* Created a new `Dockerfile-CI` to streamline the CI build process, including artifact handling, resolution configuration, and health checks. This Dockerfile is optimized for automated builds and includes necessary dependencies for HamClock.
* Simplified the existing `Dockerfile` by separating the artifact download and extraction into distinct `RUN` commands for better clarity and maintainability.