### PR TITLE
Update docker-publish.yml

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,32 +29,32 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  download:
-    name: Download Source
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
+  # download:
+  #   name: Download Source
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     contents: read
 
-    steps:
-      - name: Check IP
-        run : curl https://icanhazip.com && curl https://ipv4.icanhazip.com
+  #   steps:
+  #     - name: Check IP
+  #       run : curl https://icanhazip.com && curl https://ipv4.icanhazip.com
 
-      - name: Download from HamClock
-        run: curl -O https://www.clearskyinstitute.com/ham/HamClock/ESPHamClock.zip
+  #     - name: Download from HamClock
+  #       run: curl -O https://www.clearskyinstitute.com/ham/HamClock/ESPHamClock.zip
 
-      - name: Cache ESPHamClock.zip
-        uses: actions/upload-artifact@v4
-        with:
-          name: ESPHamClock.zip
-          path: ESPHamClock.zip
-          if-no-files-found: error
-          retention-days: 7
-          overwrite: true
+  #     - name: Cache ESPHamClock.zip
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: ESPHamClock.zip
+  #         path: ESPHamClock.zip
+  #         if-no-files-found: error
+  #         retention-days: 7
+  #         overwrite: true
 
   build:
     name: Build and push Docker image
     runs-on: ubuntu-latest
-    needs: download
+    # needs: download
     permissions:
       contents: read
       packages: write
@@ -100,11 +100,11 @@ jobs:
           flavor: |
             latest=auto
       
-      # Download the ESPHamClock.zip artifact
-      - name: Download ESPHamClock.zip artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ESPHamClock.zip
+      # # Download the ESPHamClock.zip artifact
+      # - name: Download ESPHamClock.zip artifact
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: ESPHamClock.zip
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
@@ -113,7 +113,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: Dockerfile-CI
+          # file: Dockerfile-CI
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,14 +10,14 @@ on:
   #   - cron: '22 23 * * *'
   push:
     paths:
-      - 'Dockerfile-CI'
+      - 'Dockerfile'
       - '!examples/**'
     branches: [ "main" ]
     # Publish semver tags as releases.
     tags: [ 'v*.*', 'v*.*.*' ]
   pull_request:
     paths:
-      - 'Dockerfile-CI'
+      - 'Dockerfile'
       - '!examples/**'
     branches: [ "main" ]
   workflow_dispatch:


### PR DESCRIPTION
This pull request updates the `.github/workflows/docker-publish.yml` file by commenting out the `download` job and related steps, effectively disabling functionality related to downloading and caching the `ESPHamClock.zip` artifact. Additionally, it comments out the specification of the `Dockerfile-CI` file in the build process. These changes appear to simplify or temporarily disable parts of the workflow.