### PR TITLE
Migrate to hamclock.com community backend

### DIFF
--- a/.github/workflows/docker-build-amd64.yaml
+++ b/.github/workflows/docker-build-amd64.yaml
@@ -33,7 +33,7 @@ jobs:
         run : curl https://icanhazip.com && curl https://ipv4.icanhazip.com
 
       - name: Download HamClock
-        run: curl --max-time 15 -O https://www.clearskyinstitute.com/ham/HamClock/ESPHamClock.zip
+        run: curl --max-time 15 -O https://hamclock.com/ham/HamClock/ESPHamClock.zip
       
       # Set up QEMU for cross-platform builds
       - name: Set up QEMU

--- a/.github/workflows/docker-build-amd64.yaml
+++ b/.github/workflows/docker-build-amd64.yaml
@@ -37,7 +37,7 @@ jobs:
       
       # Set up QEMU for cross-platform builds
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: linux/arm64
 
@@ -45,12 +45,12 @@ jobs:
       # multi-platform images and export cache
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Log in against to registry
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -60,7 +60,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build Docker image
         id: build-and-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile-CI

--- a/.github/workflows/docker-build-arm64.yaml
+++ b/.github/workflows/docker-build-arm64.yaml
@@ -33,7 +33,7 @@ jobs:
         run : curl https://icanhazip.com && curl https://ipv4.icanhazip.com
 
       - name: Download HamClock
-        run: curl --max-time 15 -O https://www.clearskyinstitute.com/ham/HamClock/ESPHamClock.zip
+        run: curl --max-time 15 -O https://hamclock.com/ham/HamClock/ESPHamClock.zip
       
       # Set up QEMU for cross-platform builds
       - name: Set up QEMU

--- a/.github/workflows/docker-build-arm64.yaml
+++ b/.github/workflows/docker-build-arm64.yaml
@@ -37,7 +37,7 @@ jobs:
       
       # Set up QEMU for cross-platform builds
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: linux/arm64
 
@@ -45,12 +45,12 @@ jobs:
       # multi-platform images and export cache
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Log in against to registry
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -60,7 +60,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build Docker image
         id: build-and-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile-CI

--- a/.github/workflows/docker-build-armv7.yaml
+++ b/.github/workflows/docker-build-armv7.yaml
@@ -33,7 +33,7 @@ jobs:
         run : curl https://icanhazip.com && curl https://ipv4.icanhazip.com
 
       - name: Download HamClock
-        run: curl --max-time 15 -O https://www.clearskyinstitute.com/ham/HamClock/ESPHamClock.zip
+        run: curl --max-time 15 -O https://hamclock.com/ham/HamClock/ESPHamClock.zip
       
       # Set up QEMU for cross-platform builds
       - name: Set up QEMU

--- a/.github/workflows/docker-build-armv7.yaml
+++ b/.github/workflows/docker-build-armv7.yaml
@@ -37,7 +37,7 @@ jobs:
       
       # Set up QEMU for cross-platform builds
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: linux/arm64
 
@@ -45,12 +45,12 @@ jobs:
       # multi-platform images and export cache
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Log in against to registry
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -60,7 +60,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build Docker image
         id: build-and-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile-CI

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -69,7 +69,7 @@ jobs:
           ./scripts/retry_clearskyinstitute.sh download https://hamclock.com/ham/HamClock/ESPHamClock.zip
 
       - name: Cache ESPHamClock.zip
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: ESPHamClock.zip
           path: ESPHamClock.zip
@@ -108,7 +108,7 @@ jobs:
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v4.0.0
+        uses: sigstore/cosign-installer@v4.1.2
         # with:
           # cosign-release: 'v2.2.4'
 
@@ -116,13 +116,13 @@ jobs:
       # multi-platform images and export cache
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.10.0
+        uses: docker/setup-buildx-action@v4.0.0
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3.4.0
+        uses: docker/login-action@v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -167,13 +167,13 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5.10.0
+        uses: docker/metadata-action@v6.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       
       # Download the ESPHamClock.zip artifact
       - name: Download ESPHamClock.zip artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: ESPHamClock.zip
 
@@ -181,7 +181,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile-CI

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -66,7 +66,7 @@ jobs:
         if: ${{ !startsWith(github.ref, 'refs/tags/') || env.DOWNLOAD_SUCCESS == 'false' }}
         run: |
           chmod +x scripts/retry_clearskyinstitute.sh
-          ./scripts/retry_clearskyinstitute.sh download https://www.clearskyinstitute.com/ham/HamClock/ESPHamClock.zip
+          ./scripts/retry_clearskyinstitute.sh download https://hamclock.com/ham/HamClock/ESPHamClock.zip
 
       - name: Cache ESPHamClock.zip
         uses: actions/upload-artifact@v5

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -65,8 +65,8 @@ jobs:
       - name: Download from HamClock (fallback or non-tag)
         if: ${{ !startsWith(github.ref, 'refs/tags/') || env.DOWNLOAD_SUCCESS == 'false' }}
         run: |
-          chmod +x scripts/retry_clearskyinstitute.sh
-          ./scripts/retry_clearskyinstitute.sh download https://hamclock.com/ham/HamClock/ESPHamClock.zip
+          chmod +x scripts/retry_download.sh
+          ./scripts/retry_download.sh download https://hamclock.com/ham/HamClock/ESPHamClock.zip
 
       - name: Cache ESPHamClock.zip
         uses: actions/upload-artifact@v7

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -21,11 +21,11 @@ jobs:
     - name: Get remote version
       id: get_remote_version
       env:
-        VERSION_CHECK_URL: ${{ vars.VERSION_CHECK_URL }}
+        VERSION_CHECK_URL: ${{ vars.VERSION_CHECK_URL || 'https://hamclock.com/ham/HamClock/version.pl' }}
       run: |
         set -e
         echo "Getting version from $VERSION_CHECK_URL"
-        REMOTE_VERSION=$(./scripts/retry_clearskyinstitute.sh get_version "$VERSION_CHECK_URL")
+        REMOTE_VERSION=$(./scripts/retry_download.sh get_version "$VERSION_CHECK_URL")
         echo "Remote version: $REMOTE_VERSION" >> $GITHUB_STEP_SUMMARY
         echo "remote_version=$REMOTE_VERSION" >> "$GITHUB_OUTPUT"
 
@@ -76,17 +76,17 @@ jobs:
 
     - name: Get Release Notes
       env:
-        VERSION_CHECK_URL: ${{ vars.VERSION_CHECK_URL }}
+        VERSION_CHECK_URL: ${{ vars.VERSION_CHECK_URL || 'https://hamclock.com/ham/HamClock/version.pl' }}
       run: |
         set -e
-        chmod +x ./scripts/retry_clearskyinstitute.sh
+        chmod +x ./scripts/retry_download.sh
         echo "Getting release notes from $VERSION_CHECK_URL"
-        ./scripts/retry_clearskyinstitute.sh get_content "$VERSION_CHECK_URL" ./release_notes.txt
+        ./scripts/retry_download.sh get_content "$VERSION_CHECK_URL" ./release_notes.txt
 
     - name: Download HamClock
       run: |
         set -e
-        ./scripts/retry_clearskyinstitute.sh download "https://hamclock.com/ham/HamClock/ESPHamClock.zip"
+        ./scripts/retry_download.sh download "https://hamclock.com/ham/HamClock/ESPHamClock.zip"
 
     - name: Create Release
       uses: softprops/action-gh-release@v2

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -86,7 +86,7 @@ jobs:
     - name: Download HamClock
       run: |
         set -e
-        ./scripts/retry_clearskyinstitute.sh download "https://www.clearskyinstitute.com/ham/HamClock/ESPHamClock.zip"
+        ./scripts/retry_clearskyinstitute.sh download "https://hamclock.com/ham/HamClock/ESPHamClock.zip"
 
     - name: Create Release
       uses: softprops/action-gh-release@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ RUN mkdir /hamclock
 WORKDIR /hamclock
 
 # Download HamClock source
-# Sort-of following Desktop build steps from https://www.clearskyinstitute.com/ham/HamClock/
-RUN curl -O http://www.clearskyinstitute.com/ham/HamClock/ESPHamClock.zip
+# Sort-of following Desktop build steps from https://hamclock.com/ham/HamClock/
+RUN curl -O https://hamclock.com/ham/HamClock/ESPHamClock.zip
 RUN unzip ESPHamClock.zip
 WORKDIR /hamclock/ESPHamClock
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /hamclock
 
 # Download HamClock source
 # Sort-of following Desktop build steps from https://www.clearskyinstitute.com/ham/HamClock/
-RUN curl -O https://www.clearskyinstitute.com/ham/HamClock/ESPHamClock.zip
+RUN curl -O http://www.clearskyinstitute.com/ham/HamClock/ESPHamClock.zip
 RUN unzip ESPHamClock.zip
 WORKDIR /hamclock/ESPHamClock
 
@@ -46,4 +46,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=2m --retries=3 CMD curl 
 
 # Start HamClock
 WORKDIR /hamclock/ESPHamClock
-CMD ["/usr/local/bin/hamclock", "-o"]
+CMD ["/usr/local/bin/hamclock", "-o", "-b", "hamclock.com:80"]

--- a/Dockerfile-CI
+++ b/Dockerfile-CI
@@ -18,7 +18,7 @@ WORKDIR /hamclock
 # COPY HamClock source from artifact downloaded by CI
 COPY ESPHamClock.zip /hamclock/
 
-# Sort-of following Desktop build steps from https://www.clearskyinstitute.com/ham/HamClock/
+# Sort-of following Desktop build steps from https://hamclock.com/ham/HamClock/
 RUN unzip ESPHamClock.zip
 WORKDIR /hamclock/ESPHamClock
 

--- a/Dockerfile-CI
+++ b/Dockerfile-CI
@@ -45,4 +45,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=2m --retries=3 CMD curl 
 
 # Start HamClock
 WORKDIR /hamclock/ESPHamClock
-CMD ["/usr/local/bin/hamclock", "-o"]
+CMD ["/usr/local/bin/hamclock", "-o", "-b", "hamclock.com:80"]

--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
-## ~~HamClock END OF LIFE~~ -- HamClock lives?
+## HamClock Backend Migration
 
-Well, it turns out there's a backend override built into HamClock, and hamclock.com explains it. Without getting into the details, I'll add this override to the HamClock Docker build here and push an update so these Docker-based HamClocks can continue operating.
+The Docker images now include `-b hamclock.com:80` which points HamClock at the community-operated backend server. Your Docker-based HamClock will continue working after the June 2026 shutdown of the original backend at clearskyinstitute.com.
 
-Check out https://hamclock.com for some of the details.
+See https://hamclock.com for details on the community backend.
 
-More soon.
+If you need to point at a different backend server, override the container command in your `docker-compose.yaml`:
+
+```yaml
+services:
+  web:
+    image: ghcr.io/chrisromp/hamclock-docker:latest
+    command: ["/usr/local/bin/hamclock", "-o", "-b", "your-server.example:80"]
+```
 
 ### Previously
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Chris NZ6F
 
 # HamClock Docker
 
-A Dockerized build of [HamClock](https://www.clearskyinstitute.com/ham/HamClock/) by Elwood Downey, WB0OEW.
+A Dockerized build of [HamClock](https://hamclock.com/) by Elwood Downey, WB0OEW.
 
 ![HamClock Screenshot](images/hamclock.png)
 
@@ -186,7 +186,7 @@ Likely you will see HamClock running but without your call sign, or if you were 
 
 ### HamClock Setup
 
-Please refer to the [HamClock User Guide](https://www.clearskyinstitute.com/ham/HamClock/HamClockKey.pdf) for detailed instructions, but here are a couple of settings I want to highlight:
+Please refer to the [HamClock User Guide](https://hamclock.com/ham/HamClock/HamClockKey.pdf) for detailed instructions, but here are a couple of settings I want to highlight:
 
 - **WiFi:** No need to set this up; HamClock on Docker will use your Docker network to connect to the internet.
 - **NTP:** If you want to skip the NTP (time server) latency/ping test on HamClock startup, you can set the NTP server to `OS` and HamClock will pull the time from your Docker host system.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The Docker images now include `-b hamclock.com:80` which points HamClock at the community-operated backend server. Your Docker-based HamClock will continue working after the June 2026 shutdown of the original backend at clearskyinstitute.com.
 
-See https://hamclock.com for details on the community backend.
+See https://hamclock.com for details on the community backend. GitHub source for the backend server available at https://github.com/komacke/open-hamclock-backend.
 
 If you need to point at a different backend server, override the container command in your `docker-compose.yaml`:
 
@@ -13,19 +13,9 @@ services:
     command: ["/usr/local/bin/hamclock", "-o", "-b", "your-server.example:80"]
 ```
 
-### Previously
-
-There has been news today (Jan 29 2026) that Elwood Downey, WB0OEW, has gone SK (passed away). The [HamClock website](https://www.clearskyinstitute.com/ham/HamClock/) states that HamClock's last release is 4.22 and that all HamClocks will cease working in June, 2026. 
-
-I will be archiving this repository at some point in the near term as no future releases will be occurring.
-
-`WB0OEW 73 DE NZ6F . .`
-
-Chris NZ6F
-
 # HamClock Docker
 
-A Dockerized build of [HamClock](https://hamclock.com/) by Elwood Downey, WB0OEW.
+A Dockerized build of [HamClock](https://hamclock.com/) by Elwood Downey, WB0OEW (SK).
 
 ![HamClock Screenshot](images/hamclock.png)
 

--- a/scripts/retry_clearskyinstitute.sh
+++ b/scripts/retry_clearskyinstitute.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # retry_clearskyinstitute.sh
-# A script to handle requests to clearskyinstitute.com with retry logic and exponential backoff
+# A script to handle HTTP requests with retry logic and exponential backoff
 # Usage: ./retry_clearskyinstitute.sh <action> <url> [output_file]
 # Actions: 
 #   get_version - Fetch version info (returns first line)

--- a/scripts/retry_download.sh
+++ b/scripts/retry_download.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# retry_clearskyinstitute.sh
+# retry_download.sh
 # A script to handle HTTP requests with retry logic and exponential backoff
-# Usage: ./retry_clearskyinstitute.sh <action> <url> [output_file]
+# Usage: ./retry_download.sh <action> <url> [output_file]
 # Actions: 
 #   get_version - Fetch version info (returns first line)
 #   download - Download a file


### PR DESCRIPTION
The original HamClock backend at clearskyinstitute.com is scheduled for shutdown in June 2026. A community-operated replacement is live at hamclock.com. This PR migrates all backend references so the Docker images continue working after the original server goes offline.

## Approach

- **Runtime backend override**: Added `-b hamclock.com:80` to the Docker CMD in both Dockerfiles so containers connect to the community backend at startup.
- **Source download migration**: Switched all build-time download URLs (source zip, version check) from clearskyinstitute.com to hamclock.com, which now hosts the same artifacts over HTTPS.
- **GitHub Actions upgrades**: Updated all workflow actions to current Node 24-compatible versions (actions/checkout v6, docker/setup-buildx v4, docker/login-action v4, docker/build-push-action v7, sigstore/cosign-installer v4, actions/upload-artifact v7, actions/download-artifact v8).
- **Script rename**: Renamed `retry_clearskyinstitute.sh` to `retry_download.sh` since the script is URL-agnostic.
- **VERSION_CHECK_URL default**: Added an inline fallback (`https://hamclock.com/ham/HamClock/version.pl`) in version-check.yml so the workflow functions without the repo variable being pre-configured.

## Notes

- The `-b` flag was introduced in HamClock v4.22 (the final release by the original author).
- Users can override the backend via `command:` in docker-compose if needed.
- The `VERSION_CHECK_URL` repository variable should be updated to `https://hamclock.com/ham/HamClock/version.pl` -- the inline default provides a safety net but the variable takes precedence when set.
- Action version pinning uses major versions (e.g., `v4`, `v7`) for most actions, matching existing repo conventions. Third-party actions with less frequent releases use patch-level pins (e.g., cosign-installer `v4.1.2`).